### PR TITLE
Fix address service asynchronous call

### DIFF
--- a/BlazorEcommerce/Client/Services/AddressService/AddressService.cs
+++ b/BlazorEcommerce/Client/Services/AddressService/AddressService.cs
@@ -18,7 +18,8 @@
         public async Task<Address?> AddOrUpdateAddress(Address? address)
         {
             var response = await _http.PostAsJsonAsync("api/address", address);
-            return response.Content.ReadFromJsonAsync<ServiceResponse<Address>>().Result.Data;
+            var serviceResponse = await response.Content.ReadFromJsonAsync<ServiceResponse<Address>>();
+            return serviceResponse?.Data;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace `.Result` with `await` when reading the address service response

## Testing
- `dotnet build BlazorEcommerce.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686dce3e2854833089aff33368182154