### PR TITLE
Secure configuration via environment variables

### DIFF
--- a/BlazorEcommerce/Server/Services/PaymentService/PaymentService.cs
+++ b/BlazorEcommerce/Server/Services/PaymentService/PaymentService.cs
@@ -1,5 +1,6 @@
 ﻿using Stripe;
 using Stripe.Checkout;
+using Microsoft.Extensions.Configuration;
 
 namespace BlazorEcommerce.Server.Services.PaymentService
 {
@@ -8,12 +9,14 @@ namespace BlazorEcommerce.Server.Services.PaymentService
         private readonly ICartService _cartService;
         private readonly IAuthService _authService;
         private readonly IOrderService _orderService;
-        
-        const string secret = "whsec_ba5fb99b39473bc176497f180c73fedf909ed8e5a7797341fb73df1c1a585c3b";
+        private readonly string _webhookSecret;
+        private readonly IConfiguration _configuration;
 
-        public PaymentService(ICartService cartService, IAuthService authService, IOrderService orderService)
+        public PaymentService(ICartService cartService, IAuthService authService, IOrderService orderService, IConfiguration configuration)
         {
-            StripeConfiguration.ApiKey = "sk_test_51KnsawCpfhEkHK7eSQM0zWSSuoVgKgD8XFLZyqSEwdPM4c93VdcBQMX1dymYEPmGPqTKJieiWyK32XTbJZQDXzYh00Y1E4BHPW";
+            _configuration = configuration;
+            StripeConfiguration.ApiKey = configuration["Stripe:SecretKey"];
+            _webhookSecret = configuration["Stripe:WebhookSecret"] ?? string.Empty;
 
             _cartService = cartService;
             _authService = authService;
@@ -71,7 +74,7 @@ namespace BlazorEcommerce.Server.Services.PaymentService
                 var stripeEvent = EventUtility.ConstructEvent(
                     json,
                     request.Headers["Stripe-Signature"],
-                    secret
+                    _webhookSecret
                 );
 
                 if (stripeEvent.Type == Events.CheckoutSessionCompleted)

--- a/BlazorEcommerce/Server/appsettings.json
+++ b/BlazorEcommerce/Server/appsettings.json
@@ -1,9 +1,13 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost,1433; Database=BlazorEcommerce; user id=SA; password=Database(!)Password"
+    "DefaultConnection": ""
   },
   "AppSettings": {
-    "Token":  "mysecretsupersecret" 
+    "Token": ""
+  },
+  "Stripe": {
+    "SecretKey": "",
+    "WebhookSecret": ""
   },
   "Logging": {
     "LogLevel": {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# BlazorEcommerce
+
+This project requires several runtime secrets that are no longer stored in the repository. Provide them using environment variables or your own `appsettings.json`.
+
+Required configuration keys:
+
+- `ConnectionStrings:DefaultConnection` – database connection string
+- `AppSettings:Token` – JWT signing key used by the API
+- `Stripe:SecretKey` – Stripe API secret key
+- `Stripe:WebhookSecret` – Stripe webhook signing secret
+
+Environment variables can be used with double underscore notation, e.g. `Stripe__SecretKey`.


### PR DESCRIPTION
## Summary
- remove hard coded Stripe secret usage
- strip secrets from `appsettings.json`
- document environment variable setup for running the app

## Testing
- `dotnet build BlazorEcommerce.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dcdb7df6083308117083e012ae0ae