### PR TITLE
Fix ProductDetails image wrapper class

### DIFF
--- a/BlazorEcommerce/Client/Pages/ProductDetails.razor.css
+++ b/BlazorEcommerce/Client/Pages/ProductDetails.razor.css
@@ -5,7 +5,7 @@
     margin: 0 10px 10px 10px;
 }
 
-.media-ima-wrapper {
+.media-img-wrapper {
     max-height: 500px;
     max-width: 500px;
     text-align: center;
@@ -20,8 +20,7 @@
          max-width: 300px;
     }
 
-    .media-ima-wrapper {
+    .media-img-wrapper {
         width: 100%;
         height: auto;
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- correct CSS class name for product details image wrapper

## Testing
- `dotnet build BlazorEcommerce.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dce2e0d6083309a2c5943c6dca967